### PR TITLE
Register new package test-agdapkgbot v0.1.5

### DIFF
--- a/test-agdapkgbot/url
+++ b/test-agdapkgbot/url
@@ -1,0 +1,1 @@
+https://github.com/jonaprieto/test-agdapkgbot.git

--- a/test-agdapkgbot/versions/0.1.5/sha1
+++ b/test-agdapkgbot/versions/0.1.5/sha1
@@ -1,0 +1,1 @@
+a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94

--- a/test-agdapkgbot/versions/0.1.5/test-agdapkgbot.agda-pkg
+++ b/test-agdapkgbot/versions/0.1.5/test-agdapkgbot.agda-pkg
@@ -1,0 +1,17 @@
+name:              agda-metis
+version:           0.1
+author:            Jonathan Prieto-Cubides
+homepage:          https://github.com/jonaprieto/agda-metis
+category:          [ classic, logic, theorems, provers ]
+license:           MIT
+license-file:      LICENSE
+description:       Functions and Theorems to prove proofs given by Metis Prover.
+tested-with:       2.5.2
+source-repository: https://github.com/jonaprieto/agda-metis.git
+depend:
+  - standard-library
+  - agda-prop
+include:
+  - src/
+  - test/
+  - test/simplify


### PR DESCRIPTION
Repository: [jonaprieto/test-agdapkgbot](https://github.com/jonaprieto/test-agdapkgbot)
Release:    [v0.1.5](https://github.com/jonaprieto/test-agdapkgbot/releases/tag/v0.1.5)
cc:         @jonaprieto

Please make sure that:
- [ ] CI passes for supported Agda versions (if applicable).
- [ ] Version bounds are up to date.
This PR will remain open for 24 hours for feedback (which is optional). If you get feedback, please let us know if you are making changes, and we'll merge once you're done.