### PR TITLE
Tag test-agdapkgbot v0.1.8

### DIFF
--- a/test-agdapkgbot/versions/0.1.8/sha1
+++ b/test-agdapkgbot/versions/0.1.8/sha1
@@ -1,0 +1,1 @@
+a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94

--- a/test-agdapkgbot/versions/0.1.8/test-agdapkgbot.agda-pkg
+++ b/test-agdapkgbot/versions/0.1.8/test-agdapkgbot.agda-pkg
@@ -1,0 +1,17 @@
+name:              agda-metis
+version:           0.1
+author:            Jonathan Prieto-Cubides
+homepage:          https://github.com/jonaprieto/agda-metis
+category:          [ classic, logic, theorems, provers ]
+license:           MIT
+license-file:      LICENSE
+description:       Functions and Theorems to prove proofs given by Metis Prover.
+tested-with:       2.5.2
+source-repository: https://github.com/jonaprieto/agda-metis.git
+depend:
+  - standard-library
+  - agda-prop
+include:
+  - src/
+  - test/
+  - test/simplify


### PR DESCRIPTION
Repository: [jonaprieto/test-agdapkgbot](https://github.com/jonaprieto/test-agdapkgbot)
Release:    [v0.1.8](https://github.com/jonaprieto/test-agdapkgbot)
Diff:       [vs v0.1.7](https://github.com/jonaprieto/test-agdapkgbot/compare/a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94...a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94)
`requires` vs v0.1.7: no changes
cc: @jonaprieto

Please make sure that:
- [ ] CI passes for supported Agda versions (if applicable).
- [ ] Version bounds are up to date.