### PR TITLE
Tag test-agdapkgbot v70.0.1

### DIFF
--- a/test-agdapkgbot/versions/70.0.1/sha1
+++ b/test-agdapkgbot/versions/70.0.1/sha1
@@ -1,0 +1,1 @@
+a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94

--- a/test-agdapkgbot/versions/70.0.1/test-agdapkgbot.agda-pkg
+++ b/test-agdapkgbot/versions/70.0.1/test-agdapkgbot.agda-pkg
@@ -1,0 +1,17 @@
+name:              agda-metis
+version:           0.1
+author:            Jonathan Prieto-Cubides
+homepage:          https://github.com/jonaprieto/agda-metis
+category:          [ classic, logic, theorems, provers ]
+license:           MIT
+license-file:      LICENSE
+description:       Functions and Theorems to prove proofs given by Metis Prover.
+tested-with:       2.5.2
+source-repository: https://github.com/jonaprieto/agda-metis.git
+depend:
+  - standard-library
+  - agda-prop
+include:
+  - src/
+  - test/
+  - test/simplify


### PR DESCRIPTION
Repository: [jonaprieto/test-agdapkgbot](https://github.com/jonaprieto/test-agdapkgbot)
Release:    [v70.0.1](https://github.com/jonaprieto/test-agdapkgbot)
Travis:     [![Travis Build Status](https://api.travis-ci.org/jonaprieto/test-agdapkgbot.svg?branch=v70.0.1)](https://travis-ci.org/jonaprieto/test-agdapkgbot/builds/390120236)
Diff:       [vs v61.0.1](https://github.com/jonaprieto/test-agdapkgbot/compare/a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94...a8df5b74ea2e0c007f0b7ffe24d440a35e1c6d94)
`requires` vs v61.0.1: no changes
cc: @jonaprieto

Please make sure that:
- [ ] CI passes for supported Agda versions (if applicable).
- [ ] Version bounds are up to date.